### PR TITLE
correction to nyears for totbio

### DIFF
--- a/R/outputs.R
+++ b/R/outputs.R
@@ -568,7 +568,7 @@ run_retro_pop <- function(year, model, model_name, dat_name, n_retro, mcmcon = F
 
       # copy and store mcmc results
       file.copy(from = here::here(year, 'mgmt', model, "retro", "model", "evalout.prj"),
-                to = here::here(year, 'mgmt', model, "retro", "results", paste0("mcmc_", endyr,".prj")),
+                to = here::here(year, 'mgmt', model, "retro", "results", paste0("mcmc_", endyr,".std")),
                 overwrite = TRUE)
 
     }

--- a/R/plots.R
+++ b/R/plots.R
@@ -737,16 +737,6 @@ plot_params <- function(year, folder, model_name, pars = c("q_srv1", "ABC", "nat
 #'
 #' @examples plot_retro(year, folder)
 plot_retro <- function(year, folder, n_retro=10, save=TRUE) {
-
-
-  # IGNORE THIS - HAS BEEN UPDATED ELSEWHERE
-
-
-
-
-
-
-
   peels = n_retro - 1
   max_year = year
   # loop through mcmc output
@@ -766,18 +756,23 @@ plot_retro <- function(year, folder, n_retro=10, save=TRUE) {
                           paste0("mcmc_", retro_yrs[i], ".std")),
                sep = "",  header = FALSE) -> df
 
-    df = df[(0.2 * nrow(df)):nrow(df),] # drop burn in
+    df = df[floor((0.2 * nrow(df))):nrow(df),] # drop burn in
 
-    colnames(df) = c("sigr", "q_srv1", "q_srv2", "F40", "natmort", "spawn_biom_proj",
+    nyrs_tot_biom_proj = ncol(df)- (2*length(yrs[1]:retro_yrs[i]) + 7 +
+      length(styr_rec:retro_yrs[i]) +  2*length(max(retro_yrs[i]) + 1:15) +
+      length(max(retro_yrs[i]) + 1:10))-1
+
+    colnames(df) = c("sigr", "q_srv1", "q_srv2", "F40", "natmort",
                      "ABC", "obj_fun",
                      paste0("tot_biom_", yrs[1]:retro_yrs[i]),
                      paste0("log_rec_dev_", styr_rec:retro_yrs[i]),
                      paste0("spawn_biom_", yrs[1]:retro_yrs[i]),
                      "log_mean_rec",
+                     # "spawn_biom_proj",
                      paste0("spawn_biom_proj_", max(retro_yrs[i]) + 1:15),
                      paste0("pred_catch_proj_", max(retro_yrs[i]) + 1:15),
                      paste0("rec_proj_", max(retro_yrs[i]) + 1:10),
-                     paste0("tot_biom_proj_", max(retro_yrs[i]) + 1:15))
+                     paste0("tot_biom_proj_", max(retro_yrs[i]) + 1:nyrs_tot_biom_proj))
 
     dat[[i]] = df %>% dplyr::mutate(retro_year = retro_yrs[i])
 


### PR DESCRIPTION
something odd occurs during the retrospective run where the terminal columns of projected quantities in MCMC_yyyy.std (corresponding to `tot_biom_proj`) are of variable lengths; sometimes only 13 years, sometimes 16.  Unclear where the error is occurring since a) the .tpl isn't changing and b) the .std files are of uniform length (15 years).

This leverages the fact they always occur at the end to manually assign years and simply pastes the year labels so the overall csv can be compiled and written; total biomass is not included in the plot. This will behave the same if/when we sort out why this occurs and re-run retrospectives.